### PR TITLE
Solr 8 upgrade changes.

### DIFF
--- a/solrconfig.xml
+++ b/solrconfig.xml
@@ -28,7 +28,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>5.0.0</luceneMatchVersion>
+  <luceneMatchVersion>7.0.0</luceneMatchVersion>
 
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
@@ -237,6 +237,208 @@
 
   </requestHandler>
 
+  <requestHandler name="title_search" class="solr.SearchHandler" default="true">
+    <!-- default values for query parameters can be specified, these
+         will be overridden by parameters in the request
+      -->
+     <lst name="defaults">
+       <str name="defType">edismax</str>
+       <str name="echoParams">explicit</str>
+       <str name="wt">json</str>
+       <int name="rows">10</int>
+
+       <str name="q.alt">*:*</str>
+       <str name="mm">5&lt;-1 8&lt;75%</str>
+       <str name="mm.autorelax">true</str>
+       <str name="lowercaseOperators">false</str>
+
+       <!-- this qf and pf are used by default, if not otherwise specified by
+            client. The default blacklight_config will use these for the
+            "keywords" search. See the author_qf/author_pf, title_qf, etc
+            below, which the default blacklight_config will specify for
+            those searches. You may also be interested in:
+            http://wiki.apache.org/solr/LocalParams
+       -->
+
+       <str name="qf">
+         alt_names_t^100000.0
+         title_t^10000.0
+       </str>
+       <str name="pf">
+         alt_names_t^100000.0
+         title_t^10000.0
+       </str>
+
+       <int name="ps">3</int>
+       <float name="tie">0.01</float>
+
+       <!-- NOT using marc_display because it is large and will slow things down for search results -->
+       <str name="fl">
+         id,
+         format,
+         database_display,
+         title_t,
+         title_sort,
+         alt_names_t,
+         title_statement_display,
+         title_truncated_display,
+         az_vendor_id_display,
+         az_vendor_name_display,
+         note_display,
+         note_t,
+         availability_facet,
+         electronic_resource_display,
+         record_update_date,
+         subject_display,
+         subject_facet,
+         subject_t,
+         url_finding_aid_display:[json],
+         url_more_links_display:[json],
+         electronic_resource_display:[json]
+       </str>
+
+       <str name="facet">true</str>
+       <str name="facet.mincount">1</str>
+       <str name="facet.field">format</str>
+       <str name="facet.field">subject_facet</str>
+       <str name="facet.field">availability_facet</str>
+
+       <str name="spellcheck">false</str>
+
+     </lst>
+
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+
+  </requestHandler>
+
+  <requestHandler name="subject_search" class="solr.SearchHandler" default="true">
+    <!-- default values for query parameters can be specified, these
+         will be overridden by parameters in the request
+      -->
+     <lst name="defaults">
+       <str name="defType">edismax</str>
+       <str name="echoParams">explicit</str>
+       <str name="wt">json</str>
+       <int name="rows">10</int>
+
+       <str name="q.alt">*:*</str>
+       <str name="mm">5&lt;-1 8&lt;75%</str>
+       <str name="mm.autorelax">true</str>
+       <str name="lowercaseOperators">false</str>
+
+       <!-- this qf and pf are used by default, if not otherwise specified by
+            client. The default blacklight_config will use these for the
+            "keywords" search. See the author_qf/author_pf, title_qf, etc
+            below, which the default blacklight_config will specify for
+            those searches. You may also be interested in:
+            http://wiki.apache.org/solr/LocalParams
+       -->
+
+       <str name="qf">
+         subject_t^1000000.0
+         subject_facet^1000000.0
+       </str>
+       <str name="pf">
+         subject_t^1000000.0
+         subject_facet^1000000.0
+       </str>
+       <int name="ps">3</int>
+       <float name="tie">0.01</float>
+
+       <!-- NOT using marc_display because it is large and will slow things down for search results -->
+       <str name="fl">
+         id,
+         format,
+         database_display,
+         title_t,
+         title_sort,
+         alt_names_t,
+         title_statement_display,
+         title_truncated_display,
+         az_vendor_id_display,
+         az_vendor_name_display,
+         note_display,
+         note_t,
+         availability_facet,
+         electronic_resource_display,
+         record_update_date,
+         subject_display,
+         subject_facet,
+         subject_t,
+         url_finding_aid_display:[json],
+         url_more_links_display:[json],
+         electronic_resource_display:[json]
+       </str>
+
+       <str name="facet">true</str>
+       <str name="facet.mincount">1</str>
+       <str name="facet.field">format</str>
+       <str name="facet.field">subject_facet</str>
+       <str name="facet.field">availability_facet</str>
+
+       <str name="spellcheck">false</str>
+
+     </lst>
+    <!-- In addition to defaults, "appends" params can be specified
+         to identify values which should be appended to the list of
+         multi-val params from the query (or the existing "defaults").
+      -->
+    <!-- In this example, the param "fq=instock:true" would be appended to
+         any query time fq params the user may specify, as a mechanism for
+         partitioning the index, independent of any user selected filtering
+         that may also be desired (perhaps as a result of faceted searching).
+
+         NOTE: there is *absolutely* nothing a client can do to prevent these
+         "appends" values from being used, so don't use this mechanism
+         unless you are sure you always want it.
+      -->
+    <!--
+       <lst name="appends">
+         <str name="fq">inStock:true</str>
+       </lst>
+      -->
+    <!-- "invariants" are a way of letting the Solr maintainer lock down
+         the options available to Solr clients.  Any params values
+         specified here are used regardless of what values may be specified
+         in either the query, the "defaults", or the "appends" params.
+
+         In this example, the facet.field and facet.query params would
+         be fixed, limiting the facets clients can use.  Faceting is
+         not turned on by default - but if the client does specify
+         facet=true in the request, these are the only facets they
+         will be able to see counts for; regardless of what other
+         facet.field or facet.query params they may specify.
+
+         NOTE: there is *absolutely* nothing a client can do to prevent these
+         "invariants" values from being used, so don't use this mechanism
+         unless you are sure you always want it.
+      -->
+    <!--
+       <lst name="invariants">
+         <str name="facet.field">cat</str>
+         <str name="facet.field">manu_exact</str>
+         <str name="facet.query">price:[* TO 500]</str>
+         <str name="facet.query">price:[500 TO *]</str>
+       </lst>
+      -->
+    <!-- If the default list of SearchComponents is not desired, that
+         list can either be overridden completely, or components can be
+         prepended or appended to the default list.  (see below)
+      -->
+    <!--
+       <arr name="components">
+         <str>nameOfCustomComponent1</str>
+         <str>nameOfCustomComponent2</str>
+       </arr>
+      -->
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+
+  </requestHandler>
+
   <!-- for requests to get a single document; use id=666 instead of q=id:666 -->
   <requestHandler name="document" class="solr.SearchHandler" >
     <lst name="defaults">
@@ -336,8 +538,8 @@
   <searchComponent name="suggest" class="solr.SuggestComponent">
     <lst name="suggester">
       <str name="name">mySuggester</str>
-      <str name="lookupImpl">FreeTextLookupFactory</str>
-      <str name="suggestFreeTextAnalyzerFieldType">textSuggest</str>
+      <str name="lookupImpl">FuzzyLookupFactory</str>
+      <str name="suggestAnalyzerFieldType">textSuggest</str>
       <str name="buildOnCommit">true</str>
       <str name="field">suggest</str>
     </lst>


### PR DESCRIPTION
* Replaces removed analyzers.
* Updates Lucene version match to 7.0.0
* Adds two new searchers title_search, subject_search because these are needed
for title and subject searches.